### PR TITLE
[fix] Передача товаров в заказ по полю внешний код (external_id)

### DIFF
--- a/classes/Parser.php
+++ b/classes/Parser.php
@@ -67,7 +67,7 @@ class Parser {
         $xmlItems = $xml->items->item;
         foreach($xmlItems as $xmlItem) {
             $items[] = array(
-                'productId' => (string)$xmlItem['id'],
+                'productId' => (string)$xmlItem->external_id,
                 'productName' => (string)$xmlItem->name,
                 'quantity' => (string)$xmlItem->quantity,
                 'initialPrice' => (string)$xmlItem->price


### PR DESCRIPTION
Данный фикс решает проблему (см. тикет retailCRM 98381 «Модуль интеграции с TIU.ru не передаёт внешние коды товаров в заказе»).

Модуль интеграции с TIU.ru не передаёт внешние коды товаров в заказе, хотя в XML, который генерирует TIU и который скармливается модулю интеграции, содержит поле external_id. Такое же значение внешнего кода присутствует и в XML каталога. В результате товары в заказе retailCRM отображаются неактивными серыми ссылками (как текст, а не как товар).

![image](https://user-images.githubusercontent.com/14993551/50971330-5ae60a80-1516-11e9-8f0f-95df5007b89e.png)
